### PR TITLE
Handle 'h' time notation in task parser

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -500,6 +500,17 @@ def parse_task_input(text: str, chat_tz: str):
     tzinfo = pytz.timezone(chat_tz)
     now_local = datetime.now(tzinfo)
 
+    def repl_h(m: re.Match) -> str:
+        start = m.start()
+        before = text[:start].lower()
+        if before.endswith("in ") or before.endswith("через "):
+            return m.group(0)
+        hh = int(m.group(1))
+        mn = int(m.group(2)) if m.group(2) else 0
+        return f"{hh}:{mn:02d}"
+
+    text = re.sub(r"\b(\d{1,2})h(\d{2})?\b", repl_h, text, flags=re.IGNORECASE)
+
     m1 = re.search(r"\b(\d{1,2})[./](\d{1,2})(?:[./](\d{2,4}))?\s+(\d{1,2}):(\d{2})\b", text)
     m2 = re.search(r"\b(\d{1,2}):(\d{2})\s+(\d{1,2})[./](\d{1,2})(?:[./](\d{2,4}))?\b", text)
     match_used = None

--- a/test_strict_parse.py
+++ b/test_strict_parse.py
@@ -19,5 +19,13 @@ class TestStrictDateParse(unittest.TestCase):
         expected = (past + timedelta(days=1)).replace(second=0, microsecond=0)
         self.assertEqual(due_utc, expected)
 
+    def test_h_time_format(self):
+        now_utc = datetime.now(pytz.utc)
+        due_utc, _, _ = parse_task_input('14h', 'UTC')
+        expected = now_utc.replace(hour=14, minute=0, second=0, microsecond=0)
+        if expected <= now_utc:
+            expected += timedelta(days=1)
+        self.assertEqual(due_utc, expected)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize times written with `h` suffix (e.g. `14h`) to standard `HH:MM`
- add regression test ensuring `14h` schedules the next day's 14:00

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af3f0e0f08832283b63044b3b36247