### PR TITLE
Normalize hour/minute time suffixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -500,6 +500,39 @@ def parse_task_input(text: str, chat_tz: str):
     tzinfo = pytz.timezone(chat_tz)
     now_local = datetime.now(tzinfo)
 
+    def normalize_units(txt: str) -> str:
+        def repl_hours(m: re.Match) -> str:
+            before = m.string[: m.start()].lower()
+            if re.search(r"(?:^|\s)(in|через)$", before):
+                return m.group(0)
+            hh = int(m.group("hh"))
+            mm = int(m.group("mm")) if m.group("mm") else 0
+            return f"{hh}:{mm:02d}"
+
+        hr_pattern_en = r"\b(?P<hh>\d{1,2})\s*h(?:\s*(?P<mm>\d{1,2})\s*(?:m(?:in)?s?)?)?\b"
+        hr_pattern_ru = r"\b(?P<hh>\d{1,2})\s*ч(?:\s*(?P<mm>\d{1,2})\s*(?:м|мин)?)?\b"
+        txt = re.sub(hr_pattern_en, repl_hours, txt, flags=re.IGNORECASE)
+        txt = re.sub(hr_pattern_ru, repl_hours, txt, flags=re.IGNORECASE)
+
+        def repl_minutes(m: re.Match) -> str:
+            before = m.string[: m.start()].lower()
+            if re.search(r"(?:^|\s)(in|через)$", before):
+                return m.group(0)
+            if m.start() > 0 and m.string[m.start() - 1] == ":":
+                return m.group(0)
+            total = int(m.group("m"))
+            hh = total // 60
+            mm = total % 60
+            return f"{hh}:{mm:02d}"
+
+        min_pattern_en = r"\b(?P<m>\d{1,3})\s*m(?:in|ins)?\b"
+        min_pattern_ru = r"\b(?P<m>\d{1,3})\s*м(?:ин)?\b"
+        txt = re.sub(min_pattern_en, repl_minutes, txt, flags=re.IGNORECASE)
+        txt = re.sub(min_pattern_ru, repl_minutes, txt, flags=re.IGNORECASE)
+        return txt
+
+    text = normalize_units(text)
+
     m1 = re.search(r"\b(\d{1,2})[./](\d{1,2})(?:[./](\d{2,4}))?\s+(\d{1,2}):(\d{2})\b", text)
     m2 = re.search(r"\b(\d{1,2}):(\d{2})\s+(\d{1,2})[./](\d{1,2})(?:[./](\d{2,4}))?\b", text)
     match_used = None

--- a/test_strict_parse.py
+++ b/test_strict_parse.py
@@ -19,5 +19,40 @@ class TestStrictDateParse(unittest.TestCase):
         expected = (past + timedelta(days=1)).replace(second=0, microsecond=0)
         self.assertEqual(due_utc, expected)
 
+    def test_h_time_format(self):
+        now_utc = datetime.now(pytz.utc)
+        due_utc, _, _ = parse_task_input('14h', 'UTC')
+        expected = now_utc.replace(hour=14, minute=0, second=0, microsecond=0)
+        if expected <= now_utc:
+            expected += timedelta(days=1)
+        self.assertEqual(due_utc, expected)
+
+    def test_cyrillic_hour_format(self):
+        now_utc = datetime.now(pytz.utc)
+        due_utc, _, _ = parse_task_input('14ч', 'UTC')
+        expected = now_utc.replace(hour=14, minute=0, second=0, microsecond=0)
+        if expected <= now_utc:
+            expected += timedelta(days=1)
+        self.assertEqual(due_utc, expected)
+
+    def test_hour_minute_combo(self):
+        now_utc = datetime.now(pytz.utc)
+        for txt in ['14h30min', '14ч30мин']:
+            due_utc, _, _ = parse_task_input(txt, 'UTC')
+            expected = now_utc.replace(hour=14, minute=30, second=0, microsecond=0)
+            if expected <= now_utc:
+                expected += timedelta(days=1)
+            self.assertEqual(due_utc, expected)
+
+    def test_minute_only_format(self):
+        now_utc = datetime.now(pytz.utc)
+        due_en, _, _ = parse_task_input('14min', 'UTC')
+        expected = now_utc.replace(hour=0, minute=14, second=0, microsecond=0)
+        if expected <= now_utc:
+            expected += timedelta(days=1)
+        self.assertEqual(due_en, expected)
+        due_ru, _, _ = parse_task_input('14мин', 'UTC')
+        self.assertEqual(due_en, due_ru)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- expand preprocessing to convert time expressions like `14ч`, `14мин`, `14h`, `14min`, and mixed forms (`14ч30мин`, `14h30min`) to `HH:MM`
- add regression tests covering Cyrillic hours, hour+minute combos, and minute-only cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af3f0e0f08832283b63044b3b36247